### PR TITLE
Fix Podspec

### DIFF
--- a/CieloEcommerce.podspec
+++ b/CieloEcommerce.podspec
@@ -5,6 +5,7 @@ Pod::Spec.new do |s|
 
   s.homepage         = 'https://github.com/DeveloperCielo/API-3.0-iOS'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors          = { 'Thiago Rodrigues de Paula' => 'thiago.rdp@gmail.com' }
   s.source           = { :git => 'https://github.com/DeveloperCielo/API-3.0-iOS.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'


### PR DESCRIPTION
The current podspec file causes the error when using `pod 'CieloEcommerce':
```
[!] Unable to find a specification for `CieloEcommerce`
```

And, when using `pod 'CieloEcommerce', :git => 'git@github.com:DeveloperCielo/API-3.0-iOS.git'`, the error:
```
[!] The `CieloEcommerce` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `authors`.
    - WARN  | github_sources: Github repositories should end in `.git`.
```

This PR will fix the second use and make it enable to be registered on the cocoapods server