### PR TITLE
Fix missing EC3Payment provider

### DIFF
--- a/CieloEcommerce/Classes/request/objects/EC3Payment.h
+++ b/CieloEcommerce/Classes/request/objects/EC3Payment.h
@@ -14,6 +14,7 @@
 typedef enum {
     Bradesco,
     BancoDoBrasil,
+    Cielo,
     Simulado
 } EC3PaymentProvider;
 

--- a/CieloEcommerce/Classes/request/objects/EC3Payment.m
+++ b/CieloEcommerce/Classes/request/objects/EC3Payment.m
@@ -75,6 +75,7 @@
     NSDictionary *providerDict = @{
                                    @"Bradesco": @(Bradesco),
                                    @"BancoDoBrasil": @(BancoDoBrasil),
+                                   @"Cielo": @(Cielo),
                                    @"Simulado": @(Simulado)
                                    };
     


### PR DESCRIPTION
Added 'Cielo' as a payment provider. 

This is a huge issue that makes the `success` block from `createSale` unable to serialize the response into a `sale` object.

Related issue: #4 